### PR TITLE
Add BT extensions for Route Server interaction

### DIFF
--- a/carma_nav2_behavior_tree/.clang-format
+++ b/carma_nav2_behavior_tree/.clang-format
@@ -1,0 +1,24 @@
+---
+# Reference: https://github.com/ament/ament_lint/blob/rolling/ament_clang_format/ament_clang_format/configuration/.clang-format
+# Changes made from reference:
+#   - added "IncludeBlocks: Preserve" to prevent ClangFormat from grouping #include directives against the style guide
+
+Language: Cpp
+BasedOnStyle: Google
+
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterEnum: true
+BreakBeforeBraces: Custom
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: false
+IncludeBlocks: Preserve

--- a/carma_nav2_behavior_tree/CMakeLists.txt
+++ b/carma_nav2_behavior_tree/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.22)
+project(carma_nav2_behavior_tree)
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+nav2_package()
+
+include_directories(
+  include
+)
+
+set(dependencies
+  rclcpp
+  rclcpp_action
+  rclcpp_lifecycle
+  geometry_msgs
+  sensor_msgs
+  nav2_msgs
+  nav_msgs
+  behaviortree_cpp_v3
+  tf2
+  tf2_ros
+  tf2_geometry_msgs
+  std_msgs
+  std_srvs
+  nav2_util
+  nav2_behavior_tree
+)
+
+add_library(carma_nav2_compute_and_track_route_action_bt_node SHARED plugins/action/compute_and_track_route_action.cpp)
+list(APPEND plugin_libs carma_nav2_compute_and_track_route_action_bt_node)
+
+add_library(carma_nav2_compute_route_action_bt_node SHARED plugins/action/compute_route_action.cpp)
+list(APPEND plugin_libs carma_nav2_compute_route_action_bt_node)
+
+foreach(bt_plugin ${plugin_libs})
+  ament_target_dependencies(${bt_plugin} ${dependencies})
+  target_compile_definitions(${bt_plugin} PRIVATE BT_PLUGIN_EXPORT)
+endforeach()
+
+install(TARGETS ${plugin_libs}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY include/
+  DESTINATION include/
+)
+
+ament_export_include_directories(
+  include
+)
+
+ament_export_libraries(
+  ${plugin_libs}
+)
+
+ament_export_dependencies(${dependencies})
+
+ament_package()

--- a/carma_nav2_behavior_tree/README.md
+++ b/carma_nav2_behavior_tree/README.md
@@ -1,0 +1,4 @@
+# `carma_nav2_behavior_tree`
+
+This package contains additional behavior tree (BT) nodes to supplement those in the `nav2_behavior_tree`
+package.

--- a/carma_nav2_behavior_tree/README.md
+++ b/carma_nav2_behavior_tree/README.md
@@ -1,4 +1,17 @@
 # `carma_nav2_behavior_tree`
 
 This package contains additional behavior tree (BT) nodes to supplement those in the `nav2_behavior_tree`
-package.
+package. Currently, the `nav2_behavior_tree` package does not have BT Action nodes to interface with the
+Route Server.
+
+See [Nav2 Behavior Trees](https://navigation.ros.org/behavior_trees/index.html) and
+[Writing a New Behavior Tree Plugin](https://navigation.ros.org/plugin_tutorials/docs/writing_new_bt_plugin.html)
+for more information about BTs and how they integrate with Nav2.
+
+## BT Action nodes
+
+- **ComputeRoute Action node**: sends a `ComputeRoute` ROS 2 action request to the Route Server and stores
+  the result in a Behavior Tree Blackboard variable.
+- **ComputeAndTrackRouteAction node**: sends a `ComputeAndTrackRoute` ROS 2 action request and stores/updates
+  the Route Server's generated dense path (received through a ROS 2 action feedback message) in a Behavior
+  Tree Blackboard variable.

--- a/carma_nav2_behavior_tree/include/carma_nav2_behavior_tree/plugins/action/compute_and_track_route_action.hpp
+++ b/carma_nav2_behavior_tree/include/carma_nav2_behavior_tree/plugins/action/compute_and_track_route_action.hpp
@@ -1,0 +1,63 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CARMA_NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__COMPUTE_AND_TRACK_ROUTE_ACTION_HPP_
+#define CARMA_NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__COMPUTE_AND_TRACK_ROUTE_ACTION_HPP_
+
+#include <string>
+
+#include <nav_msgs/msg/path.h>
+#include <nav2_behavior_tree/bt_action_node.hpp>
+#include <nav2_msgs/action/compute_and_track_route.hpp>
+
+namespace carma_nav2_behavior_tree
+{
+class ComputeAndTrackRouteAction
+: public nav2_behavior_tree::BtActionNode<nav2_msgs::action::ComputeAndTrackRoute>
+{
+  using Action = nav2_msgs::action::ComputeAndTrackRoute;
+  using ActionResult = Action::Result;
+  using ActionGoal = Action::Goal;
+
+public:
+  ComputeAndTrackRouteAction(
+    const std::string & xml_tag_name, const std::string & action_name,
+    const BT::NodeConfiguration & conf);
+
+  void on_tick() override;
+
+  BT::NodeStatus on_success() override;
+
+  BT::NodeStatus on_aborted() override;
+
+  BT::NodeStatus on_cancelled() override;
+
+  void on_wait_for_result(std::shared_ptr<const Action::Feedback> feedback) override;
+
+  static BT::PortsList providedPorts()
+  {
+    return providedBasicPorts({
+      BT::InputPort<std::uint16_t>("start_id", "Start node in graph"),
+      BT::InputPort<geometry_msgs::msg::PoseStamped>("start", "Start pose of the route"),
+      BT::InputPort<std::uint16_t>("goal_id", "Destination node in graph"),
+      BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination pose of the route"),
+      BT::OutputPort<nav_msgs::msg::Path>("path", "Path created by ComputeAndTrackRoute node"),
+      BT::OutputPort<ActionResult::_error_code_type>(
+        "error_code_id", "The compute path through poses error code"),
+    });
+  }
+};
+}  // namespace carma_nav2_behavior_tree
+
+#endif  // CARMA_NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__COMPUTE_AND_TRACK_ROUTE_ACTION_HPP_

--- a/carma_nav2_behavior_tree/include/carma_nav2_behavior_tree/plugins/action/compute_route_action.hpp
+++ b/carma_nav2_behavior_tree/include/carma_nav2_behavior_tree/plugins/action/compute_route_action.hpp
@@ -1,0 +1,62 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CARMA_NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__COMPUTE_ROUTE_ACTION_HPP_
+#define CARMA_NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__COMPUTE_ROUTE_ACTION_HPP_
+
+#include <string>
+
+#include <nav_msgs/msg/path.h>
+#include <nav2_behavior_tree/bt_action_node.hpp>
+#include <nav2_msgs/action/compute_route.hpp>
+
+namespace carma_nav2_behavior_tree
+{
+class ComputeRouteAction : public nav2_behavior_tree::BtActionNode<nav2_msgs::action::ComputeRoute>
+{
+  using Action = nav2_msgs::action::ComputeRoute;
+  using ActionResult = Action::Result;
+  using ActionGoal = Action::Goal;
+
+public:
+  ComputeRouteAction(
+    const std::string & xml_tag_name, const std::string & action_name,
+    const BT::NodeConfiguration & conf);
+
+  void on_tick() override;
+
+  BT::NodeStatus on_success() override;
+
+  BT::NodeStatus on_aborted() override;
+
+  BT::NodeStatus on_cancelled() override;
+
+  void halt() override;
+
+  static BT::PortsList providedPorts()
+  {
+    return providedBasicPorts({
+      BT::InputPort<std::uint16_t>("start_id", "Start node in graph"),
+      BT::InputPort<geometry_msgs::msg::PoseStamped>("start", "Start pose of the route"),
+      BT::InputPort<std::uint16_t>("goal_id", "Destination node in graph"),
+      BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination pose of the route"),
+      BT::OutputPort<nav_msgs::msg::Path>("path", "Path created by ComputeRoute node"),
+      BT::OutputPort<ActionResult::_error_code_type>(
+        "error_code_id", "The compute path through poses error code"),
+    });
+  }
+};
+}  // namespace carma_nav2_behavior_tree
+
+#endif  // CARMA_NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__COMPUTE_ROUTE_ACTION_HPP_

--- a/carma_nav2_behavior_tree/package.xml
+++ b/carma_nav2_behavior_tree/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>carma_nav2_behavior_tree</name>
+  <version>0.1.0</version>
+  <description>Behavior tree nodes to supplement those in nav2_behavior_tree</description>
+  <maintainer email="carma@dot.gov">CARMA Support</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>nav2_common</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>nav_msgs</depend>
+  <depend>nav2_behavior_tree</depend>
+  <depend>nav2_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/carma_nav2_behavior_tree/plugins/action/compute_and_track_route_action.cpp
+++ b/carma_nav2_behavior_tree/plugins/action/compute_and_track_route_action.cpp
@@ -1,0 +1,79 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "carma_nav2_behavior_tree/plugins/action/compute_and_track_route_action.hpp"
+
+namespace carma_nav2_behavior_tree
+{
+
+ComputeAndTrackRouteAction::ComputeAndTrackRouteAction(
+  const std::string & xml_tag_name, const std::string & action_name,
+  const BT::NodeConfiguration & conf)
+: BtActionNode<Action>(xml_tag_name, action_name, conf)
+{
+}
+
+void ComputeAndTrackRouteAction::on_tick()
+{
+  getInput("goal", goal_.goal);
+  goal_.use_poses = true;
+
+  if (getInput("start_id", goal_.start_id) || getInput("goal_id", goal_.goal_id)) {
+    goal_.use_poses = false;
+  }
+
+  if (getInput("start", goal_.start)) {
+    goal_.use_start = true;
+  }
+}
+
+BT::NodeStatus ComputeAndTrackRouteAction::on_success()
+{
+  setOutput("error_code_id", ActionGoal::NONE);
+  return BT::NodeStatus::SUCCESS;
+}
+
+BT::NodeStatus ComputeAndTrackRouteAction::on_aborted()
+{
+  setOutput("error_code_id", result_.result->error_code);
+  return BT::NodeStatus::FAILURE;
+}
+
+BT::NodeStatus ComputeAndTrackRouteAction::on_cancelled()
+{
+  setOutput("error_code_id", ActionGoal::NONE);
+  return BT::NodeStatus::SUCCESS;
+}
+
+void ComputeAndTrackRouteAction::on_wait_for_result(
+  std::shared_ptr<const Action::Feedback> feedback)
+{
+  if (feedback) {
+    setOutput("path", feedback->path);
+  }
+}
+
+}  // namespace carma_nav2_behavior_tree
+
+#include <behaviortree_cpp_v3/bt_factory.h>
+BT_REGISTER_NODES(factory)
+{
+  BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
+    return std::make_unique<carma_nav2_behavior_tree::ComputeAndTrackRouteAction>(
+      name, "compute_and_track_route", config);
+  };
+
+  factory.registerBuilder<carma_nav2_behavior_tree::ComputeAndTrackRouteAction>(
+    "ComputeAndTrackRoute", builder);
+}

--- a/carma_nav2_behavior_tree/plugins/action/compute_route_action.cpp
+++ b/carma_nav2_behavior_tree/plugins/action/compute_route_action.cpp
@@ -1,0 +1,82 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "carma_nav2_behavior_tree/plugins/action/compute_route_action.hpp"
+
+namespace carma_nav2_behavior_tree
+{
+
+ComputeRouteAction::ComputeRouteAction(
+  const std::string & xml_tag_name, const std::string & action_name,
+  const BT::NodeConfiguration & conf)
+: BtActionNode<Action>(xml_tag_name, action_name, conf)
+{
+}
+
+void ComputeRouteAction::on_tick()
+{
+  getInput("goal", goal_.goal);
+  goal_.use_poses = true;
+
+  if (getInput("start_id", goal_.start_id) || getInput("goal_id", goal_.goal_id)) {
+    goal_.use_poses = false;
+  }
+
+  if (getInput("start", goal_.start)) {
+    goal_.use_start = true;
+  }
+}
+
+BT::NodeStatus ComputeRouteAction::on_success()
+{
+  setOutput("path", result_.result->path);
+  setOutput("error_code_id", ActionGoal::NONE);
+  return BT::NodeStatus::SUCCESS;
+}
+
+BT::NodeStatus ComputeRouteAction::on_aborted()
+{
+  nav_msgs::msg::Path empty_path;
+  setOutput("path", empty_path);
+  setOutput("error_code_id", result_.result->error_code);
+  return BT::NodeStatus::FAILURE;
+}
+
+BT::NodeStatus ComputeRouteAction::on_cancelled()
+{
+  nav_msgs::msg::Path empty_path;
+  setOutput("path", empty_path);
+  setOutput("error_code_id", ActionGoal::NONE);
+  return BT::NodeStatus::SUCCESS;
+}
+
+void ComputeRouteAction::halt()
+{
+  nav_msgs::msg::Path empty_path;
+  setOutput("path", empty_path);
+  BtActionNode::halt();
+}
+
+}  // namespace carma_nav2_behavior_tree
+
+#include <behaviortree_cpp_v3/bt_factory.h>
+BT_REGISTER_NODES(factory)
+{
+  BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
+    return std::make_unique<carma_nav2_behavior_tree::ComputeRouteAction>(
+      name, "compute_route", config);
+  };
+
+  factory.registerBuilder<carma_nav2_behavior_tree::ComputeRouteAction>("ComputeRoute", builder);
+}


### PR DESCRIPTION
# PR Details
## Description

This PR adds Behavior Tree (BT) Action nodes that interact with Nav2's Route Server. The Route Server is currently experimental, and there is no provided BT Action that interacts with it. The only demo/example involves the Nav2 simple command API, which is unsuitable for our needs.

## Related GitHub Issue

## Related Jira Key

Closes [CF-827](https://usdot-carma.atlassian.net/browse/CF-827)

## Motivation and Context

## How Has This Been Tested?

Manually with some initial integration testing.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-827]: https://usdot-carma.atlassian.net/browse/CF-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ