### PR TITLE
Add port drayage demo package

### DIFF
--- a/carma_nav2_port_drayage_demo/.clang-format
+++ b/carma_nav2_port_drayage_demo/.clang-format
@@ -1,0 +1,24 @@
+---
+# Reference: https://github.com/ament/ament_lint/blob/rolling/ament_clang_format/ament_clang_format/configuration/.clang-format
+# Changes made from reference:
+#   - added "IncludeBlocks: Preserve" to prevent ClangFormat from grouping #include directives against the style guide
+
+Language: Cpp
+BasedOnStyle: Google
+
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterEnum: true
+BreakBeforeBraces: Custom
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: false
+IncludeBlocks: Preserve

--- a/carma_nav2_port_drayage_demo/CMakeLists.txt
+++ b/carma_nav2_port_drayage_demo/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+project(carma_nav2_port_drayage_demo)
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+ament_auto_add_library(carma_nav2_port_drayage_demo
+  src/port_drayage_demo.cpp
+)
+
+ament_auto_add_executable(carma_nav2_port_drayage_demo_node
+  src/port_drayage_demo_node.cpp
+)
+
+ament_auto_package()

--- a/carma_nav2_port_drayage_demo/README.md
+++ b/carma_nav2_port_drayage_demo/README.md
@@ -1,0 +1,5 @@
+# `carma_nav2_port_drayage_demo` package
+
+This package implements port drayage integration with a Nav2-based autonomy stack. The package's node listens for
+incoming port drayage variants of `MobilityOperation.msg` messages then sends the target location to the Nav2 Waypoint
+Follower via a ROS 2 action call.

--- a/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
+++ b/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
@@ -1,0 +1,48 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CARMA_NAV2_PORT_DRAYAGE_DEMO__PORT_DRAYAGE_DEMO_HPP_
+#define CARMA_NAV2_PORT_DRAYAGE_DEMO__PORT_DRAYAGE_DEMO_HPP_
+
+#include <carma_v2x_msgs/msg/mobility_operation.hpp>
+#include <nav2_msgs/action/follow_waypoints.hpp>
+#include <nav2_util/lifecycle_node.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+
+namespace carma_nav2_port_drayage_demo
+{
+class PortDrayageDemo : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  explicit PortDrayageDemo(const rclcpp::NodeOptions & options);
+
+  auto on_configure(const rclcpp_lifecycle::State & state) -> nav2_util::CallbackReturn override;
+
+  auto on_activate(const rclcpp_lifecycle::State & state) -> nav2_util::CallbackReturn override;
+
+  auto on_deactivate(const rclcpp_lifecycle::State & state) -> nav2_util::CallbackReturn override;
+
+  auto on_mobility_operation_received(const carma_v2x_msgs::msg::MobilityOperation & msg) -> void;
+
+private:
+  rclcpp::Subscription<carma_v2x_msgs::msg::MobilityOperation>::SharedPtr
+    mobility_operation_subscription_{nullptr};
+
+  rclcpp_action::Client<nav2_msgs::action::FollowWaypoints>::SharedPtr follow_waypoints_client_{
+    nullptr};
+};
+}  // namespace carma_nav2_port_drayage_demo
+
+#endif  // CARMA_NAV2_PORT_DRAYAGE_DEMO__PORT_DRAYAGE_DEMO_HPP_

--- a/carma_nav2_port_drayage_demo/package.xml
+++ b/carma_nav2_port_drayage_demo/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>carma_nav2_port_drayage_demo</name>
+  <version>0.1.0</version>
+  <description>A port drayage demo navigation2 application</description>
+  <maintainer email="carma@dot.gov">CARMA Support</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>carma_v2x_msgs</depend>
+  <depend>nav2_msgs</depend>
+  <depend>nav2_util</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+
+  <build_depend>nlohmann_json_dev</build_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
@@ -1,0 +1,99 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "carma_nav2_port_drayage_demo/port_drayage_demo.hpp"
+
+#include <nav2_msgs/action/follow_waypoints.hpp>
+#include <nav2_util/lifecycle_node.hpp>
+#include <nlohmann/json.hpp>
+
+namespace carma_nav2_port_drayage_demo
+{
+PortDrayageDemo::PortDrayageDemo(const rclcpp::NodeOptions & options)
+: rclcpp_lifecycle::LifecycleNode("port_drayage_demo", options)
+{
+  RCLCPP_INFO(get_logger(), "Creating");
+}
+
+auto PortDrayageDemo::on_configure(const rclcpp_lifecycle::State & /* state */)
+  -> nav2_util::CallbackReturn
+{
+  RCLCPP_INFO(get_logger(), "Configuring");
+
+  follow_waypoints_client_ = rclcpp_action::create_client<nav2_msgs::action::FollowWaypoints>(
+    get_node_base_interface(), get_node_graph_interface(), get_node_logging_interface(),
+    get_node_waitables_interface(), "follow_waypoints");
+
+  mobility_operation_subscription_ = create_subscription<carma_v2x_msgs::msg::MobilityOperation>(
+    "input/mobility_operation", 1, [this](const carma_v2x_msgs::msg::MobilityOperation & msg) {
+      on_mobility_operation_received(msg);
+    });
+
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+auto PortDrayageDemo::on_activate(const rclcpp_lifecycle::State & /* state */)
+  -> nav2_util::CallbackReturn
+{
+  RCLCPP_INFO(get_logger(), "Activating");
+
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+auto PortDrayageDemo::on_deactivate(const rclcpp_lifecycle::State & /* state */)
+  -> nav2_util::CallbackReturn
+{
+  RCLCPP_INFO(get_logger(), "Deactivating");
+
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+auto PortDrayageDemo::on_mobility_operation_received(
+  const carma_v2x_msgs::msg::MobilityOperation & msg) -> void
+{
+  if (msg.strategy != "carma/port_drayage") {
+    RCLCPP_ERROR_STREAM(
+      get_logger(),
+      "Could not process MobilityOperation message: expected strategy 'carma/port_drayage': "
+      "received strategy '"
+        << msg.strategy << "'");
+
+    return;
+  }
+
+  try {
+    const auto strategy_params_json = nlohmann::json::parse(msg.strategy_params);
+
+    const auto longitude{strategy_params_json["destination"]["longitude"].template get<float>()};
+    const auto latitude{strategy_params_json["destination"]["latitude"].template get<float>()};
+
+    RCLCPP_INFO_STREAM(get_logger(), longitude << ", " << latitude);
+
+    nav2_msgs::action::FollowWaypoints::Goal goal;
+
+    geometry_msgs::msg::PoseStamped pose;
+    pose.header.frame_id = "map";
+    pose.pose.position.x = longitude;
+    pose.pose.position.y = latitude;
+
+    goal.poses.push_back(std::move(pose));
+
+    follow_waypoints_client_->async_send_goal(goal);
+  } catch (const nlohmann::json::exception & e) {
+    RCLCPP_ERROR_STREAM(
+      get_logger(), "Could not process MobilityOperation message: JSON error: " << e.what());
+  }
+}
+
+}  // namespace carma_nav2_port_drayage_demo

--- a/carma_nav2_port_drayage_demo/src/port_drayage_demo_node.cpp
+++ b/carma_nav2_port_drayage_demo/src/port_drayage_demo_node.cpp
@@ -1,0 +1,31 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <carma_nav2_port_drayage_demo/port_drayage_demo.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+auto main(int argc, char * argv[]) -> int
+{
+  rclcpp::init(argc, argv);
+
+  auto node{std::make_shared<carma_nav2_port_drayage_demo::PortDrayageDemo>(rclcpp::NodeOptions{})};
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.spin();
+
+  rclcpp::shutdown();
+
+  return 0;
+}


### PR DESCRIPTION
# PR Details
## Description

This PR adds the initial implementation for port drayage integration with a Nav2-based autonomy stack.

## Related GitHub Issue

## Related Jira Key

Closes [CF-833](https://usdot-carma.atlassian.net/browse/CF-833)

## Motivation and Context

We want port drayage functionality for the C1T trucks.

## How Has This Been Tested?

Limited testing in the standard TB3 simulation environment.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-833]: https://usdot-carma.atlassian.net/browse/CF-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ