### PR TITLE
CF 889 Port Drayage Unit Testing

### DIFF
--- a/carma_nav2_port_drayage_demo/CMakeLists.txt
+++ b/carma_nav2_port_drayage_demo/CMakeLists.txt
@@ -28,8 +28,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_port_drayage_demo test/test_port_drayage_demo.cpp)
 
-  ament_target_dependencies(test_port_drayage_demo ${${PROJECT_NAME}_FOUND_TEST_DEPENDS})
-
   target_link_libraries(test_port_drayage_demo carma_nav2_port_drayage_demo)
 
 endif()

--- a/carma_nav2_port_drayage_demo/CMakeLists.txt
+++ b/carma_nav2_port_drayage_demo/CMakeLists.txt
@@ -4,6 +4,10 @@ project(carma_nav2_port_drayage_demo)
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
+include_directories(
+  include/
+)
+
 ament_auto_add_library(carma_nav2_port_drayage_demo
   src/port_drayage_demo.cpp
 )
@@ -11,5 +15,23 @@ ament_auto_add_library(carma_nav2_port_drayage_demo
 ament_auto_add_executable(carma_nav2_port_drayage_demo_node
   src/port_drayage_demo_node.cpp
 )
+
+target_link_libraries(carma_nav2_port_drayage_demo_node
+  carma_nav2_port_drayage_demo
+)
+
+# Testing
+if(BUILD_TESTING)
+
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies() # This populates the ${${PROJECT_NAME}_FOUND_TEST_DEPENDS} variable#
+
+  ament_add_gtest(test_port_drayage_demo test/test_port_drayage_demo.cpp)
+
+  ament_target_dependencies(test_port_drayage_demo ${${PROJECT_NAME}_FOUND_TEST_DEPENDS})
+
+  target_link_libraries(test_port_drayage_demo carma_nav2_port_drayage_demo)
+
+endif()
 
 ament_auto_package()

--- a/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
+++ b/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
@@ -16,100 +16,103 @@
 #define CARMA_NAV2_PORT_DRAYAGE_DEMO__PORT_DRAYAGE_DEMO_HPP_
 
 #include <carma_v2x_msgs/msg/mobility_operation.hpp>
-#include <nav2_msgs/action/follow_waypoints.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <memory>
+#include <nav2_msgs/action/follow_waypoints.hpp>
 #include <nav2_util/lifecycle_node.hpp>
+#include <nlohmann/json.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
-#include <nlohmann/json.hpp>
+#include <string>
 
 namespace carma_nav2_port_drayage_demo
 {
 
 class OperationID
 {
-  public:
-    /**
-     * \brief Enum containing possible operation IDs used to define destinations for port drayage.
-     */
-    enum Operation {
-      PICKUP,
-      DROPOFF,
-      ENTER_STAGING_AREA,
-      EXIT_STAGING_AREA,
-      ENTER_PORT,
-      EXIT_PORT,
-      PORT_CHECKPOINT,
-      HOLDING_AREA,
-      DEFAULT_OPERATION,
-    };
+public:
+  /**
+    * \brief Enum containing possible operation IDs used to define destinations for port drayage.
+    */
+  enum Operation
+  {
+    PICKUP,
+    DROPOFF,
+    ENTER_STAGING_AREA,
+    EXIT_STAGING_AREA,
+    ENTER_PORT,
+    EXIT_PORT,
+    PORT_CHECKPOINT,
+    HOLDING_AREA,
+    DEFAULT_OPERATION,
+  };
 
-    /**
-     * \brief Standard constructor for OperationID
-     * \param op Operation enum associated with this object.
-     */
-    OperationID(enum Operation op) :
-      operation_enum_(op) {};
+  /**
+    * \brief Standard constructor for OperationID
+    * \param op Operation enum associated with this object.
+    */
+  explicit OperationID(enum Operation op) : operation_enum_(op) {}
 
-    /**
-     * \brief Create OperationID using a string
-     * \param op_str String to used to create the Operation
-     */
-    OperationID(std::string op_str);
+  /**
+    * \brief Create OperationID using a string
+    * \param op_str String to used to create the Operation
+    */
+  explicit OperationID(std::string op_str);
 
-    /**
-     * \brief Getter function to obtain the Operation enum associated with this object.
-     * \return Operation enum associated with this object.
-     */
-    OperationID::Operation getOperationID() const;
+  /**
+    * \brief Getter function to obtain the Operation enum associated with this object.
+    * \return Operation enum associated with this object.
+    */
+  OperationID::Operation getOperationID() const;
 
-    /**
-     * \brief Function to convert a string to Operation
-     * \param op_str String to convert to an Operation
-     */
-    OperationID::Operation stringToOperation(std::string op_str) const;
+  /**
+    * \brief Function to convert a string to Operation
+    * \param op_str String to convert to an Operation
+    */
+  OperationID::Operation stringToOperation(std::string op_str) const;
 
-    /**
-     * \brief Function to convert this object's 'operation_enum_' to a human-readable string.
-     * \return A human-readable string representing this object's 'operation_enum_'.
-     */
-    std::string operationToString() const;
+  /**
+    * \brief Function to convert this object's 'operation_enum_' to a human-readable string.
+    * \return A human-readable string representing this object's 'operation_enum_'.
+    */
+  std::string operationToString() const;
 
-    /**
-     * \brief Stream operator for this object.
-     */
-    friend std::ostream& operator<<(std::ostream& output, const OperationID& oid){
-      return output << oid.operationToString();
-    }
+  /**
+    * \brief Stream operator for this object.
+    */
+  friend std::ostream & operator<<(std::ostream & output, const OperationID & oid)
+  {
+    return output << oid.operationToString();
+  }
 
-    /**
-     * \brief Overloaded == operator for comparision with String objects.
-     */
-    friend bool operator==(const std::string& lhs, const OperationID& rhs) {
-      return lhs == rhs.operationToString();
-    }
+  /**
+    * \brief Overloaded == operator for comparision with String objects.
+    */
+  friend bool operator==(const std::string & lhs, const OperationID & rhs)
+  {
+    return lhs == rhs.operationToString();
+  }
 
-  private:
-    // Data member containing this object's Operation enum value
-    const Operation operation_enum_ = Operation::DEFAULT_OPERATION;
+private:
+  // Data member containing this object's Operation enum value
+  const Operation operation_enum_ = Operation::DEFAULT_OPERATION;
 };
-
 
 struct PortDrayageMobilityOperationMsg
 {
-    std::string cargo_id;
-    std::shared_ptr<OperationID> operation;
-    std::string current_action_id; // Identifier for the action this message is related to
-    double dest_longitude;  // Destination longitude for the carma vehicle
-    double dest_latitude;   // Destination latitude for the carma vehicle
-    double start_longitude; // Starting longitude of the carma vehicle
-    double start_latitude;  // Starting latitude of the carma vehicle
-    PortDrayageMobilityOperationMsg()
-    {
-      operation = std::shared_ptr<OperationID>(new OperationID{OperationID::Operation::ENTER_STAGING_AREA});
-    }
+  std::string cargo_id;
+  std::shared_ptr<OperationID> operation;
+  std::string current_action_id;  // Identifier for the action this message is related to
+  double dest_longitude;          // Destination longitude for the carma vehicle
+  double dest_latitude;           // Destination latitude for the carma vehicle
+  double start_longitude;         // Starting longitude of the carma vehicle
+  double start_latitude;          // Starting latitude of the carma vehicle
+  PortDrayageMobilityOperationMsg()
+  {
+    operation =
+      std::shared_ptr<OperationID>(new OperationID{OperationID::Operation::ENTER_STAGING_AREA});
+  }
 };
-
 
 class PortDrayageDemo : public rclcpp_lifecycle::LifecycleNode
 {
@@ -124,7 +127,9 @@ public:
 
   auto on_mobility_operation_received(const carma_v2x_msgs::msg::MobilityOperation & msg) -> void;
 
-  auto on_result_received(const rclcpp_action::ClientGoalHandle<nav2_msgs::action::FollowWaypoints>::WrappedResult & result) -> void;
+  auto on_result_received(
+    const rclcpp_action::ClientGoalHandle<nav2_msgs::action::FollowWaypoints>::WrappedResult &
+      result) -> void;
 
   auto on_odometry_received(const geometry_msgs::msg::PoseWithCovarianceStamped & msg) -> void;
 

--- a/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
+++ b/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
@@ -133,6 +133,8 @@ public:
 
   auto on_odometry_received(const geometry_msgs::msg::PoseWithCovarianceStamped & msg) -> void;
 
+  auto compose_arrival_message() -> carma_v2x_msgs::msg::MobilityOperation;
+
   auto extract_port_drayage_message(const carma_v2x_msgs::msg::MobilityOperation & msg) -> bool;
 
   auto set_cmv_id(std::string cmv_id) -> void { cmv_id_ = cmv_id; }

--- a/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
+++ b/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
@@ -139,8 +139,6 @@ public:
 
   auto get_cmv_id() -> std::string { return cmv_id_; }
 
-  auto set_cargo_id(std::string cargo_id) -> std::string { return cargo_id_; }
-
   auto get_cargo_id() -> std::string { return cargo_id_; }
 
   auto is_actively_executing_operation() -> bool { return actively_executing_operation_; }

--- a/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
+++ b/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
@@ -135,7 +135,7 @@ public:
 
   auto extract_port_drayage_message(const carma_v2x_msgs::msg::MobilityOperation & msg) -> bool;
 
-  auto set_cmv_id(std::string cmv_id) -> void { cmv_id_ =  cmv_id; }
+  auto set_cmv_id(std::string cmv_id) -> void { cmv_id_ = cmv_id; }
 
   auto get_cmv_id() -> std::string { return cmv_id_; }
 

--- a/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
+++ b/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
@@ -110,7 +110,7 @@ struct PortDrayageMobilityOperationMsg
   PortDrayageMobilityOperationMsg()
   {
     operation =
-      std::shared_ptr<OperationID>(new OperationID{OperationID::Operation::ENTER_STAGING_AREA});
+      std::shared_ptr<OperationID>(new OperationID{OperationID::Operation::DEFAULT_OPERATION});
   }
 };
 

--- a/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
+++ b/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
@@ -135,6 +135,16 @@ public:
 
   auto extract_port_drayage_message(const carma_v2x_msgs::msg::MobilityOperation & msg) -> bool;
 
+  auto set_cmv_id(std::string cmv_id) -> void { cmv_id_ =  cmv_id; }
+
+  auto get_cmv_id() -> std::string { return cmv_id_; }
+
+  auto set_cargo_id(std::string cargo_id) -> std::string { return cargo_id_; }
+
+  auto get_cargo_id() -> std::string { return cargo_id_; }
+
+  auto is_actively_executing_operation() -> bool { return actively_executing_operation_; }
+
 private:
   rclcpp::Subscription<carma_v2x_msgs::msg::MobilityOperation>::SharedPtr
     mobility_operation_subscription_{nullptr};

--- a/carma_nav2_port_drayage_demo/package.xml
+++ b/carma_nav2_port_drayage_demo/package.xml
@@ -8,6 +8,7 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>ament_auto_cmake</build_depend>
 
   <depend>carma_v2x_msgs</depend>
   <depend>nav2_msgs</depend>
@@ -19,6 +20,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
@@ -222,6 +222,11 @@ auto PortDrayageDemo::extract_port_drayage_message(
         "Ignoring received port drayage MobilityOperation message intended for cmv_id %s",
         cmv_id.c_str());
       return false;
+    } else if (msg.strategy != "carma/port_drayage") {
+      RCLCPP_WARN(
+        get_logger(), "Ignoring received MobilityOperation message with strategy %s",
+        msg.strategy.c_str());
+      return false;
     }
 
     previous_mobility_operation_msg_.dest_longitude =

--- a/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
@@ -14,9 +14,6 @@
 
 #include "carma_nav2_port_drayage_demo/port_drayage_demo.hpp"
 
-#include <nav2_msgs/action/follow_waypoints.hpp>
-#include <nav2_util/lifecycle_node.hpp>
-
 namespace carma_nav2_port_drayage_demo
 {
 
@@ -147,6 +144,7 @@ auto PortDrayageDemo::on_mobility_operation_received(
   send_goal_options.result_callback =
     std::bind(&PortDrayageDemo::on_result_received, this, std::placeholders::_1);
   follow_waypoints_client_->async_send_goal(goal, send_goal_options);
+  actively_executing_operation_ = true;
 }
 
 auto PortDrayageDemo::on_result_received(
@@ -191,6 +189,7 @@ auto PortDrayageDemo::on_result_received(
       mobility_operation_json["cargo"] = cargo_id_ != "";
       result.strategy_params = mobility_operation_json.dump();
       mobility_operation_publisher_->publish(std::move(result));
+      actively_executing_operation_ = false;
       return;
     }
     case rclcpp_action::ResultCode::ABORTED:

--- a/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
@@ -20,47 +20,61 @@
 namespace carma_nav2_port_drayage_demo
 {
 
-OperationID::OperationID(std::string op_str) :
-operation_enum_(stringToOperation(op_str)) {}
+OperationID::OperationID(std::string op_str) : operation_enum_(stringToOperation(op_str)) {}
 
-OperationID::Operation OperationID::getOperationID() const {
-  return operation_enum_;
-}
+OperationID::Operation OperationID::getOperationID() const { return operation_enum_; }
 
-OperationID::Operation OperationID::stringToOperation(std::string op_str) const {
-  if (op_str == "PICKUP")                   return Operation::PICKUP;
-  else if (op_str == "DROPOFF")             return Operation::DROPOFF;
-  else if (op_str == "ENTER_STAGING_AREA")  return Operation::ENTER_STAGING_AREA;
-  else if (op_str == "EXIT_STAGING_AREA")   return Operation::EXIT_STAGING_AREA;
-  else if (op_str == "ENTER_PORT")          return Operation::ENTER_PORT;
-  else if (op_str == "EXIT_PORT")           return Operation::EXIT_PORT;
-  else if (op_str == "PORT_CHECKPOINT")     return Operation::PORT_CHECKPOINT;
-  else if (op_str == "HOLDING_AREA")        return Operation::HOLDING_AREA;
+OperationID::Operation OperationID::stringToOperation(std::string op_str) const
+{
+  if (op_str == "PICKUP")
+    return Operation::PICKUP;
+  else if (op_str == "DROPOFF")
+    return Operation::DROPOFF;
+  else if (op_str == "ENTER_STAGING_AREA")
+    return Operation::ENTER_STAGING_AREA;
+  else if (op_str == "EXIT_STAGING_AREA")
+    return Operation::EXIT_STAGING_AREA;
+  else if (op_str == "ENTER_PORT")
+    return Operation::ENTER_PORT;
+  else if (op_str == "EXIT_PORT")
+    return Operation::EXIT_PORT;
+  else if (op_str == "PORT_CHECKPOINT")
+    return Operation::PORT_CHECKPOINT;
+  else if (op_str == "HOLDING_AREA")
+    return Operation::HOLDING_AREA;
   else {
     RCLCPP_WARN_STREAM(rclcpp::get_logger("OperationID"), "Received unknown Operation " << op_str);
     return Operation::DEFAULT_OPERATION;
   }
 }
 
-std::string OperationID::operationToString() const {
-
+std::string OperationID::operationToString() const
+{
   // Convert operation enum into a human-readable string
-  switch(operation_enum_) {
-    case Operation::PICKUP:             return "PICKUP";
-    case Operation::DROPOFF:            return "DROPOFF";
-    case Operation::ENTER_STAGING_AREA: return "ENTER_STAGING_AREA";
-    case Operation::EXIT_STAGING_AREA:  return "EXIT_STAGING_AREA";
-    case Operation::ENTER_PORT:         return "ENTER_PORT";
-    case Operation::EXIT_PORT:          return "EXIT_PORT";
-    case Operation::PORT_CHECKPOINT:    return "PORT_CHECKPOINT";
-    case Operation::HOLDING_AREA:       return "HOLDING_AREA";
+  switch (operation_enum_) {
+    case Operation::PICKUP:
+      return "PICKUP";
+    case Operation::DROPOFF:
+      return "DROPOFF";
+    case Operation::ENTER_STAGING_AREA:
+      return "ENTER_STAGING_AREA";
+    case Operation::EXIT_STAGING_AREA:
+      return "EXIT_STAGING_AREA";
+    case Operation::ENTER_PORT:
+      return "ENTER_PORT";
+    case Operation::EXIT_PORT:
+      return "EXIT_PORT";
+    case Operation::PORT_CHECKPOINT:
+      return "PORT_CHECKPOINT";
+    case Operation::HOLDING_AREA:
+      return "HOLDING_AREA";
     default:
-      RCLCPP_WARN_STREAM(rclcpp::get_logger("OperationID"), "Conversion of an unsupported operation enum value to a string.");
+      RCLCPP_WARN_STREAM(
+        rclcpp::get_logger("OperationID"),
+        "Conversion of an unsupported operation enum value to a string.");
       return "DEFAULT_OPERATION";
   }
 }
-
-
 
 PortDrayageDemo::PortDrayageDemo(const rclcpp::NodeOptions & options)
 : rclcpp_lifecycle::LifecycleNode("port_drayage_demo", options)
@@ -71,7 +85,6 @@ PortDrayageDemo::PortDrayageDemo(const rclcpp::NodeOptions & options)
 auto PortDrayageDemo::on_configure(const rclcpp_lifecycle::State & /* state */)
   -> nav2_util::CallbackReturn
 {
-
   get_parameter("cmv_id", cmv_id_);
 
   clock_ = get_clock();
@@ -90,8 +103,8 @@ auto PortDrayageDemo::on_configure(const rclcpp_lifecycle::State & /* state */)
       on_odometry_received(msg);
     });
 
-  mobility_operation_publisher_ = create_publisher<carma_v2x_msgs::msg::MobilityOperation>(
-    "outgoing_mobility_operation", 1);
+  mobility_operation_publisher_ =
+    create_publisher<carma_v2x_msgs::msg::MobilityOperation>("outgoing_mobility_operation", 1);
 
   actively_executing_operation_ = false;
 
@@ -115,10 +128,9 @@ auto PortDrayageDemo::on_mobility_operation_received(
 {
   if (actively_executing_operation_) {
     RCLCPP_WARN_STREAM(
-      get_logger(),
-      "Ignoring received port drayage operation '"
-        << msg.strategy_params << "' while already executing the operation '"
-        << previous_mobility_operation_msg_.operation << "'");
+      get_logger(), "Ignoring received port drayage operation '"
+                      << msg.strategy_params << "' while already executing the operation '"
+                      << previous_mobility_operation_msg_.operation << "'");
 
     return;
   }
@@ -130,26 +142,27 @@ auto PortDrayageDemo::on_mobility_operation_received(
   pose.pose.position.x = previous_mobility_operation_msg_.dest_longitude;
   pose.pose.position.y = previous_mobility_operation_msg_.dest_latitude;
   goal.poses.push_back(std::move(pose));
-  auto send_goal_options = rclcpp_action::Client<nav2_msgs::action::FollowWaypoints>::SendGoalOptions();
+  auto send_goal_options =
+    rclcpp_action::Client<nav2_msgs::action::FollowWaypoints>::SendGoalOptions();
   send_goal_options.result_callback =
     std::bind(&PortDrayageDemo::on_result_received, this, std::placeholders::_1);
   follow_waypoints_client_->async_send_goal(goal, send_goal_options);
 }
 
 auto PortDrayageDemo::on_result_received(
-  const rclcpp_action::ClientGoalHandle<nav2_msgs::action::FollowWaypoints>::WrappedResult & result) -> void
+  const rclcpp_action::ClientGoalHandle<nav2_msgs::action::FollowWaypoints>::WrappedResult & result)
+  -> void
 {
-  switch (result.code)
-  {
-    case rclcpp_action::ResultCode::SUCCEEDED:
-    {
+  switch (result.code) {
+    case rclcpp_action::ResultCode::SUCCEEDED: {
       // Create arrival message
       carma_v2x_msgs::msg::MobilityOperation result;
       // Populate message header
       result.m_header.sender_id = cmv_id_;
       result.m_header.recipient_id = "";
       result.m_header.plan_id = "";
-      result.m_header.timestamp = clock_->now().nanoseconds()/1E6; // uint64 milliseconds since unix epoch
+      result.m_header.timestamp =
+        clock_->now().nanoseconds() / 1E6;  // epoch to uint64 milliseconds
       // Set strategy
       result.strategy = "carma/port_drayage";
       // Set JSON fields
@@ -158,20 +171,20 @@ auto PortDrayageDemo::on_result_received(
       location_json["latitude"] = current_odometry_.pose.pose.position.y;
       mobility_operation_json["location"] = location_json;
       mobility_operation_json["cmv_id"] = cmv_id_;
-      mobility_operation_json["operation"] = previous_mobility_operation_msg_.operation->operationToString();
+      mobility_operation_json["operation"] =
+        previous_mobility_operation_msg_.operation->operationToString();
       mobility_operation_json["action_id"] = previous_mobility_operation_msg_.current_action_id;
       // Update Cargo ID and set JSON field
-      if (previous_mobility_operation_msg_.operation->getOperationID() == OperationID::Operation::PICKUP)
-      {
+      if (
+        previous_mobility_operation_msg_.operation->getOperationID() ==
+        OperationID::Operation::PICKUP) {
         cargo_id_ = previous_mobility_operation_msg_.cargo_id;
         mobility_operation_json["cargo_id"] = cargo_id_;
-      }
-      else if (previous_mobility_operation_msg_.operation->getOperationID() == OperationID::Operation::DROPOFF)
-      {
+      } else if (
+        previous_mobility_operation_msg_.operation->getOperationID() ==
+        OperationID::Operation::DROPOFF) {
         cargo_id_ = "";
-      }
-      else if (cargo_id_ != "")
-      {
+      } else if (cargo_id_ != "") {
         mobility_operation_json["cargo_id"] = cargo_id_;
       }
 
@@ -192,33 +205,40 @@ auto PortDrayageDemo::on_result_received(
   }
 }
 
-auto PortDrayageDemo::on_odometry_received(const geometry_msgs::msg::PoseWithCovarianceStamped & msg)
-  -> void
+auto PortDrayageDemo::on_odometry_received(
+  const geometry_msgs::msg::PoseWithCovarianceStamped & msg) -> void
 {
   current_odometry_ = msg;
 }
 
-auto PortDrayageDemo::extract_port_drayage_message(const carma_v2x_msgs::msg::MobilityOperation & msg)
-  -> bool
+auto PortDrayageDemo::extract_port_drayage_message(
+  const carma_v2x_msgs::msg::MobilityOperation & msg) -> bool
 {
   try {
     const auto strategy_params_json = nlohmann::json::parse(msg.strategy_params);
     const auto cmv_id{strategy_params_json["cmv_id"].template get<std::string>()};
-    if (cmv_id != cmv_id_)
-    {
-      RCLCPP_WARN(get_logger(), "Ignoring received port drayage MobilityOperation message intended for cmv_id %s", cmv_id.c_str());
+    if (cmv_id != cmv_id_) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Ignoring received port drayage MobilityOperation message intended for cmv_id %s",
+        cmv_id.c_str());
       return false;
     }
 
-    previous_mobility_operation_msg_.dest_longitude = strategy_params_json["destination"]["longitude"].template get<double>();
-    previous_mobility_operation_msg_.dest_latitude = strategy_params_json["destination"]["latitude"].template get<double>();
-    previous_mobility_operation_msg_.operation = std::shared_ptr<OperationID>(new OperationID(strategy_params_json["operation"].template get<std::string>()));
-    previous_mobility_operation_msg_.cargo_id = strategy_params_json["cargo_id"].template get<std::string>();
-    previous_mobility_operation_msg_.current_action_id = strategy_params_json["action_id"].template get<std::string>();
+    previous_mobility_operation_msg_.dest_longitude =
+      strategy_params_json["destination"]["longitude"].template get<double>();
+    previous_mobility_operation_msg_.dest_latitude =
+      strategy_params_json["destination"]["latitude"].template get<double>();
+    previous_mobility_operation_msg_.operation = std::shared_ptr<OperationID>(
+      new OperationID(strategy_params_json["operation"].template get<std::string>()));
+    previous_mobility_operation_msg_.cargo_id =
+      strategy_params_json["cargo_id"].template get<std::string>();
+    previous_mobility_operation_msg_.current_action_id =
+      strategy_params_json["action_id"].template get<std::string>();
   } catch (const nlohmann::json::exception & e) {
     RCLCPP_ERROR_STREAM(
       get_logger(), "Could not process MobilityOperation message: JSON error: " << e.what());
-      return false;
+    return false;
   }
   return true;
 }

--- a/carma_nav2_port_drayage_demo/test/test_port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/test/test_port_drayage_demo.cpp
@@ -1,0 +1,39 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+#include <carma_nav2_port_drayage_demo/port_drayage_demo.hpp>
+
+TEST(PortDrayageTest, dummyTest) { ASSERT_EQ(4, 2 + 2); }
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // Initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool success = RUN_ALL_TESTS();
+
+  // Shutdown ROS
+  rclcpp::shutdown();
+
+  return success;
+}

--- a/carma_nav2_port_drayage_demo/test/test_port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/test/test_port_drayage_demo.cpp
@@ -18,10 +18,43 @@
 #include <iostream>
 #include <memory>
 #include <thread>
+#include <nlohmann/json.hpp>
 
 #include <carma_nav2_port_drayage_demo/port_drayage_demo.hpp>
 
-TEST(PortDrayageTest, dummyTest) { ASSERT_EQ(4, 2 + 2); }
+TEST(PortDrayageTest, cmvIdTest)
+{
+  auto node{std::make_shared<carma_nav2_port_drayage_demo::PortDrayageDemo>(rclcpp::NodeOptions{})};
+  node->on_configure(node->get_current_state());
+  node->set_cmv_id("test_cmv_id");
+  // Create Mobility Operation Message
+  carma_v2x_msgs::msg::MobilityOperation cmd;
+  cmd.m_header.sender_id = "not_test_cmv_id";
+  cmd.strategy = "carma/port_drayage";
+  // Set JSON fields
+  nlohmann::json mobility_operation_json, location_json;
+  location_json["longitude"] = 0.0;
+  location_json["latitude"] = 0.0;
+  mobility_operation_json["destination"] = location_json;
+  mobility_operation_json["cmv_id"] = "not_test_cmv_id";
+  mobility_operation_json["operation"] = "PICKUP";
+  mobility_operation_json["action_id"] = "some_action";
+  mobility_operation_json["cargo_id"] = "new_cargo";
+  mobility_operation_json["cargo"] = true;
+  cmd.strategy_params = mobility_operation_json.dump();
+  node->on_mobility_operation_received(cmd);
+  ASSERT_FALSE(node->is_actively_executing_operation());
+  cmd.m_header.sender_id = "test_cmv_id";
+  mobility_operation_json["cmv_id"] = "test_cmv_id";
+  cmd.strategy_params = mobility_operation_json.dump();
+  node->on_mobility_operation_received(cmd);
+  ASSERT_TRUE(node->is_actively_executing_operation());
+  rclcpp_action::ClientGoalHandle<nav2_msgs::action::FollowWaypoints>::WrappedResult result;
+  result.code = rclcpp_action::ResultCode::SUCCEEDED;
+  node->on_result_received(result);
+  ASSERT_EQ(node->get_cargo_id(), "new_cargo");
+  ASSERT_FALSE(node->is_actively_executing_operation());
+}
 
 int main(int argc, char ** argv)
 {

--- a/carma_nav2_port_drayage_demo/test/test_port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/test/test_port_drayage_demo.cpp
@@ -17,11 +17,12 @@
 #include <future>
 #include <iostream>
 #include <memory>
-#include <thread>
 #include <nlohmann/json.hpp>
+#include <thread>
 
 #include <carma_nav2_port_drayage_demo/port_drayage_demo.hpp>
 
+// Test vehicle only responds to incoming mobility operation messages that match its cmv_id
 TEST(PortDrayageTest, cmvIdTest)
 {
   auto node{std::make_shared<carma_nav2_port_drayage_demo::PortDrayageDemo>(rclcpp::NodeOptions{})};
@@ -47,6 +48,39 @@ TEST(PortDrayageTest, cmvIdTest)
   cmd.m_header.sender_id = "test_cmv_id";
   mobility_operation_json["cmv_id"] = "test_cmv_id";
   cmd.strategy_params = mobility_operation_json.dump();
+  node->on_mobility_operation_received(cmd);
+  ASSERT_TRUE(node->is_actively_executing_operation());
+  rclcpp_action::ClientGoalHandle<nav2_msgs::action::FollowWaypoints>::WrappedResult result;
+  result.code = rclcpp_action::ResultCode::SUCCEEDED;
+  node->on_result_received(result);
+  ASSERT_EQ(node->get_cargo_id(), "new_cargo");
+  ASSERT_FALSE(node->is_actively_executing_operation());
+}
+
+// Test vehicle only responds to incoming mobility operation messages with strategy carma/port_drayage
+TEST(PortDrayageTest, strategyTest)
+{
+  auto node{std::make_shared<carma_nav2_port_drayage_demo::PortDrayageDemo>(rclcpp::NodeOptions{})};
+  node->on_configure(node->get_current_state());
+  node->set_cmv_id("test_cmv_id");
+  // Create Mobility Operation Message
+  carma_v2x_msgs::msg::MobilityOperation cmd;
+  cmd.m_header.sender_id = "test_cmv_id";
+  cmd.strategy = "some_other_strategy";
+  // Set JSON fields
+  nlohmann::json mobility_operation_json, location_json;
+  location_json["longitude"] = 0.0;
+  location_json["latitude"] = 0.0;
+  mobility_operation_json["destination"] = location_json;
+  mobility_operation_json["cmv_id"] = "test_cmv_id";
+  mobility_operation_json["operation"] = "PICKUP";
+  mobility_operation_json["action_id"] = "some_action";
+  mobility_operation_json["cargo_id"] = "new_cargo";
+  mobility_operation_json["cargo"] = true;
+  cmd.strategy_params = mobility_operation_json.dump();
+  node->on_mobility_operation_received(cmd);
+  ASSERT_FALSE(node->is_actively_executing_operation());
+  cmd.strategy = "carma/port_drayage";
   node->on_mobility_operation_received(cmd);
   ASSERT_TRUE(node->is_actively_executing_operation());
   rclcpp_action::ClientGoalHandle<nav2_msgs::action::FollowWaypoints>::WrappedResult result;

--- a/carma_nav2_port_drayage_demo/test/test_port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/test/test_port_drayage_demo.cpp
@@ -90,6 +90,47 @@ TEST(PortDrayageTest, strategyTest)
   ASSERT_FALSE(node->is_actively_executing_operation());
 }
 
+// Test vehicle pickup and dropoff
+TEST(PortDrayageTest, activelyExecutingTest)
+{
+  // PICKUP
+  auto node{std::make_shared<carma_nav2_port_drayage_demo::PortDrayageDemo>(rclcpp::NodeOptions{})};
+  node->on_configure(node->get_current_state());
+  node->set_cmv_id("test_cmv_id");
+  // Create Mobility Operation Message
+  carma_v2x_msgs::msg::MobilityOperation cmd;
+  cmd.m_header.sender_id = "test_cmv_id";
+  cmd.strategy = "carma/port_drayage";
+  // Set JSON fields
+  nlohmann::json mobility_operation_json, location_json;
+  location_json["longitude"] = 0.0;
+  location_json["latitude"] = 0.0;
+  mobility_operation_json["destination"] = location_json;
+  mobility_operation_json["cmv_id"] = "test_cmv_id";
+  mobility_operation_json["operation"] = "PICKUP";
+  mobility_operation_json["action_id"] = "some_action";
+  mobility_operation_json["cargo_id"] = "new_cargo";
+  mobility_operation_json["cargo"] = true;
+  cmd.strategy_params = mobility_operation_json.dump();
+  node->on_mobility_operation_received(cmd);
+  ASSERT_TRUE(node->is_actively_executing_operation());
+  ASSERT_EQ(node->get_cargo_id(), "");
+  rclcpp_action::ClientGoalHandle<nav2_msgs::action::FollowWaypoints>::WrappedResult result;
+  result.code = rclcpp_action::ResultCode::SUCCEEDED;
+  node->on_result_received(result);
+  ASSERT_EQ(node->get_cargo_id(), "new_cargo");
+  ASSERT_FALSE(node->is_actively_executing_operation());
+  // DROPOFF
+  mobility_operation_json["operation"] = "DROPOFF";
+  cmd.strategy_params = mobility_operation_json.dump();
+  node->on_mobility_operation_received(cmd);
+  ASSERT_TRUE(node->is_actively_executing_operation());
+  ASSERT_EQ(node->get_cargo_id(), "new_cargo");
+  node->on_result_received(result);
+  ASSERT_EQ(node->get_cargo_id(), "");
+  ASSERT_FALSE(node->is_actively_executing_operation());
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
# PR Details
## Description

This PR adds unit tests for the `carma_nav2_port_drayage_demo` package. Minor bugs found from developing units tests have also been fixed.

## Related GitHub Issue

NA

## Related Jira Key

[CF-889](https://usdot-carma.atlassian.net/browse/CF-889)

## Motivation and Context

Since we now have a basic port drayage demonstration implemented, it’s important that we develop unit tests to verify the current functionality and reduce the likelihood of introducing bugs in future development.

## How Has This Been Tested?

1. Tests compile using `colcon build --packages-select carma_nav2_port_drayage_demo`
2. Tests run using `colcon test --package-select carma_nav2_port_drayage_demo`
3. All tests pass when checked using `colcon test-result --all`
4. Code coverage of unit tests is 87% when checked using `gcovr`. Steps to run this are:
    a. `colcon build --packages-select carma_nav2_port_drayage_demo --cmake-args -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="--coverage" -DCMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON`
    b. `colcon test --package-select carma_nav2_port_drayage_demo`
    c. `gcovr`

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CF-889]: https://usdot-carma.atlassian.net/browse/CF-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ