### PR TITLE
CF 899 Emergency Stop

### DIFF
--- a/carma_nav2_emergency_stop/CMakeLists.txt
+++ b/carma_nav2_emergency_stop/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+project(carma_nav2_emergency_stop)
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+ament_auto_add_library(carma_nav2_emergency_stop
+  src/emergency_stop.cpp
+)
+
+ament_auto_add_executable(carma_nav2_emergency_stop_node
+  src/emergency_stop_node.cpp
+)
+
+ament_auto_package()

--- a/carma_nav2_emergency_stop/README.md
+++ b/carma_nav2_emergency_stop/README.md
@@ -1,0 +1,3 @@
+# `carma_nav2_emergency_stop` package
+
+This package adds emergency stop functionality to shutdown the Navigation2 stack and send a halt command when the center button on the Logitech Gamepad F710 is pushed.

--- a/carma_nav2_emergency_stop/include/carma_nav2_emergency_stop/emergency_stop.hpp
+++ b/carma_nav2_emergency_stop/include/carma_nav2_emergency_stop/emergency_stop.hpp
@@ -1,0 +1,46 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CARMA_NAV2_EMERGENCY_STOP__EMERGENCY_STOP_HPP_
+#define CARMA_NAV2_EMERGENCY_STOP__EMERGENCY_STOP_HPP_
+
+#include <nav2_util/lifecycle_node.hpp>
+#include <nav2_util/lifecycle_service_client.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+#include <ackermann_msgs/msg/ackermann_drive_stamped.hpp>
+#include <sensor_msgs/msg/joy.hpp>
+
+namespace carma_nav2_emergency_stop
+{
+
+class EmergencyStop : public rclcpp::Node
+{
+public:
+  explicit EmergencyStop(const rclcpp::NodeOptions & options);
+
+  auto on_joy_received(const sensor_msgs::msg::Joy & msg) -> void;
+
+private:
+  rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr
+    joy_subscription_{nullptr};
+
+  rclcpp::Publisher<ackermann_msgs::msg::AckermannDriveStamped>::SharedPtr
+    ackermann_publisher_{nullptr};
+
+  // The names of the nodes to be managed, in the order of desired bring-up
+  std::vector<std::string> node_names_;
+};
+}  // namespace carma_nav2_emergency_stop
+
+#endif  // CARMA_NAV2_EMERGENCY_STOP__EMERGENCY_STOP_HPP_

--- a/carma_nav2_emergency_stop/package.xml
+++ b/carma_nav2_emergency_stop/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>carma_nav2_emergency_stop</name>
+  <version>0.1.0</version>
+  <description>An emergency stop for navigation2</description>
+  <maintainer email="carma@dot.gov">CARMA Support</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>nav2_msgs</depend>
+  <depend>nav2_util</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>sensor_msgs</depend>
+  <depend>nav2_lifecycle_manager</depend>
+  <depend>ackermann_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/carma_nav2_emergency_stop/src/emergency_stop.cpp
+++ b/carma_nav2_emergency_stop/src/emergency_stop.cpp
@@ -1,0 +1,51 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "carma_nav2_emergency_stop/emergency_stop.hpp"
+
+namespace carma_nav2_emergency_stop
+{
+
+EmergencyStop::EmergencyStop(const rclcpp::NodeOptions & options)
+: rclcpp::Node("emergency_stop", options)
+{
+  declare_parameter("node_names", rclcpp::PARAMETER_STRING_ARRAY);
+  node_names_ = get_parameter("node_names").as_string_array();
+  joy_subscription_ = create_subscription<sensor_msgs::msg::Joy>(
+    "joy", 1, [this](const sensor_msgs::msg::Joy & msg) {
+      on_joy_received(msg);
+    });
+  ackermann_publisher_ = create_publisher<ackermann_msgs::msg::AckermannDriveStamped>(
+    "ackermann_cmd", 1
+  );
+}
+
+auto EmergencyStop::on_joy_received(
+  const sensor_msgs::msg::Joy & msg) -> void
+{
+    if (msg.buttons[8])  // Middle Logitech button is the kill switch
+    {
+      RCLCPP_ERROR(get_logger(), "KILL SWITCH ENABLED");
+      for (auto name : node_names_)
+      {
+        nav2_util::LifecycleServiceClient lifecycle_client{name, shared_from_this()};
+        lifecycle_client.change_state(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+        lifecycle_client.change_state(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+      }
+      ackermann_msgs::msg::AckermannDriveStamped msg;
+      ackermann_publisher_->publish(msg);
+      rclcpp::shutdown();
+    }
+}
+}  // namespace carma_nav2_emergency_stop

--- a/carma_nav2_emergency_stop/src/emergency_stop_node.cpp
+++ b/carma_nav2_emergency_stop/src/emergency_stop_node.cpp
@@ -1,0 +1,31 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <carma_nav2_emergency_stop/emergency_stop.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+auto main(int argc, char * argv[]) -> int
+{
+  rclcpp::init(argc, argv);
+
+  auto node{std::make_shared<carma_nav2_emergency_stop::EmergencyStop>(rclcpp::NodeOptions{})};
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.spin();
+
+  rclcpp::shutdown();
+
+  return 0;
+}


### PR DESCRIPTION
# PR Details
## Description

This PR introduces a new package with a node that acts as an emergency stop for Nav2. If the center button on the Logitech controller is pressed, the node uses the Nav2 lifecycle manager to shutdown all Nav2 nodes and sends a command to the vehicle to hault before exiting.

Related PR: https://github.com/usdot-fhwa-stol/c1t_bringup/pull/25

## Related GitHub Issue

NA

## Related Jira Key

[CF-899](https://usdot-carma.atlassian.net/browse/CF-899)

## Motivation and Context

Currently the only way to stop the C1T system during operation is to manually send a CTRL+C command to the terminal where the c1t_bringup launch has been called. Since several terminals may be open at a given time the vehicle may not be immediately stopped in cases where control is lost. A C1T E-stop should be enabled on a controller so that a developer can quickly stop the vehicle as soon as an issue is identified to prevent collisions.

## How Has This Been Tested?

On pushing the emergency stop button, an empty AckermannDrive message  is sent and the nav2 nodes are all shut down. This was tested on the vehicle while following a route and the vehicle immediately  stopped and would no longer start up when given a new goal.

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-899]: https://usdot-carma.atlassian.net/browse/CF-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ