### PR TITLE
Cf 902 multiple lanes

### DIFF
--- a/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
@@ -137,6 +137,7 @@ auto PortDrayageDemo::on_mobility_operation_received(
     return;
   }
   if (!extract_port_drayage_message(msg)) return;
+  rclcpp::sleep_for(std::chrono::seconds(2));
   nav2_msgs::action::FollowWaypoints::Goal goal;
 
   geometry_msgs::msg::PoseStamped pose;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR adds logic for switching route graphs during the port drayage demo based on whether or not the truck passes/fails inspection. If the truck fails inspection, the standard exit will disappear from the route graph in place of the inspection lane. After the truck exits the port, it will then switch back to the original graph.

Related PR: https://github.com/usdot-fhwa-stol/c1t_bringup/pull/28

## Related GitHub Issue

NA

## Related Jira Key

[CF-902](https://usdot-carma.atlassian.net/browse/CF-902)

## Motivation and Context

Since the Nav2 motion planning algorithm will always try to take the lowest cost path, or in this case shortest path, we need a method to prevent the vehicle from cutting through lanes it should not enter (i.e. cutting through the inspection lane).

## How Has This Been Tested?

Tested on the blue truck using manually published incoming MOMs. Procedure:

1. Send the vehicle to one of the 3 lanes manually using the Rviz goal command
2. Send a MOM that instructs the vehicle to enter the holding area (i.e. inspection lane) and observe the route graph switch to include the inspection lane
3. Send a MOM that instructs the vehicle to exit the port and observe the route graph switch back to include the standard exit
4. Repeat skipping 2 and observe the vehicle take the standard path to exit the port

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CF-902]: https://usdot-carma.atlassian.net/browse/CF-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ