### PR TITLE
Cf 910 send rviz ack

### DIFF
--- a/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
+++ b/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
@@ -17,6 +17,9 @@
 
 #include <carma_v2x_msgs/msg/mobility_operation.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <action_msgs/msg/goal_status_array.hpp>
+#include <action_msgs/msg/goal_status.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
 #include <memory>
 #include <nav2_msgs/action/follow_waypoints.hpp>
 #include <nav2_util/lifecycle_node.hpp>
@@ -151,6 +154,12 @@ public:
   auto on_odometry_received(const geometry_msgs::msg::PoseWithCovarianceStamped & msg) -> void;
 
   /**
+   * \brief Callback that contains status information on Nav2 goals sent from Rviz
+   * \param msg Goal status
+   */
+  auto on_rviz_goal_status_received(const action_msgs::msg::GoalStatusArray & msg) -> void;
+
+  /**
    * \brief Helper function to compose the ack published in on_result_received
    */
   auto compose_arrival_message() -> carma_v2x_msgs::msg::MobilityOperation;
@@ -190,6 +199,9 @@ private:
 
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
     odometry_subscription_{nullptr};
+
+  rclcpp::Subscription<action_msgs::msg::GoalStatusArray>::SharedPtr
+    rviz_action_subscription_{nullptr};
 
   rclcpp::Publisher<carma_v2x_msgs::msg::MobilityOperation>::SharedPtr
     mobility_operation_publisher_{nullptr};

--- a/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
@@ -221,9 +221,9 @@ auto PortDrayageDemo::extract_port_drayage_message(
     }
 
     previous_mobility_operation_msg_.dest_longitude =
-      strategy_params_json["destination"]["longitude"].template get<double>();
+      std::stod(strategy_params_json["destination"]["longitude"].template get<std::string>());
     previous_mobility_operation_msg_.dest_latitude =
-      strategy_params_json["destination"]["latitude"].template get<double>();
+      std::stod(strategy_params_json["destination"]["latitude"].template get<std::string>());
     previous_mobility_operation_msg_.operation = std::shared_ptr<OperationID>(
       new OperationID(strategy_params_json["operation"].template get<std::string>()));
     previous_mobility_operation_msg_.cargo_id =

--- a/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
@@ -197,6 +197,7 @@ auto PortDrayageDemo::on_rviz_goal_status_received(
       carma_v2x_msgs::msg::MobilityOperation result = compose_arrival_message();
       mobility_operation_publisher_->publish(std::move(result));
       actively_executing_operation_ = false;
+      rviz_action_subscription_.reset(); 
     }
   }
 }

--- a/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
@@ -189,7 +189,6 @@ auto PortDrayageDemo::on_rviz_goal_status_received(
   if (!actively_executing_operation_) {
     if (goal.status == action_msgs::msg::GoalStatus::STATUS_ACCEPTED || goal.status == action_msgs::msg::GoalStatus::STATUS_EXECUTING) {
       previous_mobility_operation_msg_.operation = std::shared_ptr<OperationID>(new OperationID(OperationID::Operation::ENTER_STAGING_AREA));
-      previous_mobility_operation_msg_.current_action_id = "one";
       actively_executing_operation_ = true;
     }
   } else {


### PR DESCRIPTION
# PR Details
## Description

This PR adds a subscription to the `port_drayage_demo_node` that listens to the status of `navigate_to_pose` actions and sends a Mobility Operation message acknowledgement when an action is completed.

## Related GitHub Issue

NA

## Related Jira Key

[CF-910](https://usdot-carma.atlassian.net/browse/CF-910)

## Motivation and Context

To engage the Port Drayage demo, we need to publish an initial acknowledgement once the vehicle reaches the port entrance to notify V2XHub it is ready for instructions. Manually publishing this is tedious and time consuming, so setting a trigger for this to happen automatically will help ensure the demo goes smoother.

## How Has This Been Tested?

Tested in both the Gazebo simulator and on the physical truck. Confirmed an ack is sent after the first Rviz goal.

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-910]: https://usdot-carma.atlassian.net/browse/CF-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ