### PR TITLE
Add delay before sending goal after receiving MOM

### DIFF
--- a/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
@@ -137,6 +137,7 @@ auto PortDrayageDemo::on_mobility_operation_received(
     return;
   }
   if (!extract_port_drayage_message(msg)) return;
+  rclcpp::sleep_for(std::chrono::seconds(2));
   nav2_msgs::action::FollowWaypoints::Goal goal;
 
   geometry_msgs::msg::PoseStamped pose;


### PR DESCRIPTION

# PR Details
## Description

This PR adds a delay between receiving a MOM command from infrastructure and engaging the navigation system.

## Related GitHub Issue

NA

## Related Jira Key

[CF-902](https://usdot-carma.atlassian.net/browse/CF-902)

## Motivation and Context

When running the port drayage demo, the truck did not come to a complete stop after completing an action because it immediately got a new command from infrastructure. This PR adds a delay between receiving a command and acting on it to smooth out the starts/stops.

## How Has This Been Tested?

Tested on the truck and confirmed with the client that 2 seconds was the desired wait time.

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-902]: https://usdot-carma.atlassian.net/browse/CF-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ