### PR TITLE
made message processing delay a parameter

### DIFF
--- a/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
+++ b/carma_nav2_port_drayage_demo/include/carma_nav2_port_drayage_demo/port_drayage_demo.hpp
@@ -216,6 +216,8 @@ private:
   geometry_msgs::msg::PoseWithCovarianceStamped current_odometry_;
   // Vehicle identifier
   std::string cmv_id_;
+  // Delay between receiving and processing goal message
+  int message_processing_delay_;
   // Cargo identified
   std::string cargo_id_;
   // Flag for whether vehicle is busy

--- a/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
+++ b/carma_nav2_port_drayage_demo/src/port_drayage_demo.cpp
@@ -77,12 +77,14 @@ PortDrayageDemo::PortDrayageDemo(const rclcpp::NodeOptions & options)
 : rclcpp_lifecycle::LifecycleNode("port_drayage_demo", options)
 {
   declare_parameter("cmv_id", rclcpp::ParameterValue(std::string("")));
+  declare_parameter("message_processing_delay", 0);
 }
 
 auto PortDrayageDemo::on_configure(const rclcpp_lifecycle::State & /* state */)
   -> nav2_util::CallbackReturn
 {
   get_parameter("cmv_id", cmv_id_);
+  get_parameter("message_processing_delay", message_processing_delay_);
 
   clock_ = get_clock();
 
@@ -137,7 +139,7 @@ auto PortDrayageDemo::on_mobility_operation_received(
     return;
   }
   if (!extract_port_drayage_message(msg)) return;
-  rclcpp::sleep_for(std::chrono::seconds(2));
+  rclcpp::sleep_for(std::chrono::seconds(message_processing_delay_));
   nav2_msgs::action::FollowWaypoints::Goal goal;
 
   geometry_msgs::msg::PoseStamped pose;


### PR DESCRIPTION
# PR Details
## Description

This PR makes the delay added between receiving a goal destination and activating the C1T system a configurable ROS2 parameter.

Related PR: [c1t_bringup #31](https://github.com/usdot-fhwa-stol/c1t_bringup/pull/31)

## Related GitHub Issue

NA

## Related Jira Key

[CF-915](https://usdot-carma.atlassian.net/browse/CF-915)

## Motivation and Context

The message processing delay will want to be modified based on the context the system is running in, so this PR makes this a configurable parameter to avoid having to recompile the C++ code.

## How Has This Been Tested?

Tested with the turtlebot simulator, confirmed that the parameter is loaded in correctly

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CF-915]: https://usdot-carma.atlassian.net/browse/CF-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ