### PR TITLE
CF 965 Enable Dynamic Rerouting

### DIFF
--- a/nav2_port_drayage_demo/include/nav2_port_drayage_demo/port_drayage_demo.hpp
+++ b/nav2_port_drayage_demo/include/nav2_port_drayage_demo/port_drayage_demo.hpp
@@ -188,8 +188,6 @@ public:
 
   auto get_cargo_id() -> std::string { return cargo_id_; }
 
-  auto is_actively_executing_operation() -> bool { return actively_executing_operation_; }
-
 private:
   ////
   // Pubs & Subs
@@ -220,8 +218,6 @@ private:
   int message_processing_delay_;
   // Cargo identified
   std::string cargo_id_;
-  // Flag for whether vehicle is busy
-  bool actively_executing_operation_ = false;
   // Clock
   rclcpp::Clock::SharedPtr clock_;
   // Previously received Mobility Operation message

--- a/nav2_port_drayage_demo/test/test_port_drayage_demo.cpp
+++ b/nav2_port_drayage_demo/test/test_port_drayage_demo.cpp
@@ -44,17 +44,14 @@ TEST(PortDrayageTest, cmvIdTest)
   mobility_operation_json["cargo"] = true;
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_FALSE(node->is_actively_executing_operation());
   cmd.m_header.sender_id = "test_cmv_id";
   mobility_operation_json["cmv_id"] = "test_cmv_id";
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   rclcpp_action::ClientGoalHandle<nav2_msgs::action::FollowWaypoints>::WrappedResult result;
   result.code = rclcpp_action::ResultCode::SUCCEEDED;
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "new_cargo");
-  ASSERT_FALSE(node->is_actively_executing_operation());
 }
 
 // Test vehicle only responds to incoming mobility operation messages with strategy carma/port_drayage
@@ -79,15 +76,12 @@ TEST(PortDrayageTest, strategyTest)
   mobility_operation_json["cargo"] = true;
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_FALSE(node->is_actively_executing_operation());
   cmd.strategy = "carma/port_drayage";
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   rclcpp_action::ClientGoalHandle<nav2_msgs::action::FollowWaypoints>::WrappedResult result;
   result.code = rclcpp_action::ResultCode::SUCCEEDED;
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "new_cargo");
-  ASSERT_FALSE(node->is_actively_executing_operation());
 }
 
 // Test vehicle pickup and dropoff
@@ -113,22 +107,18 @@ TEST(PortDrayageTest, pickupAndDropoffTest)
   mobility_operation_json["cargo"] = true;
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   ASSERT_EQ(node->get_cargo_id(), "");
   rclcpp_action::ClientGoalHandle<nav2_msgs::action::FollowWaypoints>::WrappedResult result;
   result.code = rclcpp_action::ResultCode::SUCCEEDED;
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "new_cargo");
-  ASSERT_FALSE(node->is_actively_executing_operation());
   // DROPOFF
   mobility_operation_json["operation"] = "DROPOFF";
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   ASSERT_EQ(node->get_cargo_id(), "new_cargo");
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "");
-  ASSERT_FALSE(node->is_actively_executing_operation());
 }
 
 // Test vehicle ack formatting
@@ -188,88 +178,68 @@ TEST(PortDrayageTest, fullDemoTest)
   mobility_operation_json["cargo"] = true;
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   rclcpp_action::ClientGoalHandle<nav2_msgs::action::FollowWaypoints>::WrappedResult result;
   result.code = rclcpp_action::ResultCode::SUCCEEDED;
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "");
-  ASSERT_FALSE(node->is_actively_executing_operation());
   // PICKUP
   mobility_operation_json["operation"] = "PICKUP";
   mobility_operation_json["cargo_id"] = "CARGO_A";
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "CARGO_A");
-  ASSERT_FALSE(node->is_actively_executing_operation());
   // EXIT STAGING AREA
   mobility_operation_json["operation"] = "EXIT_STAGING_AREA";
   mobility_operation_json["cargo_id"] = "";
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "CARGO_A");
-  ASSERT_FALSE(node->is_actively_executing_operation());
   // ENTER PORT
   mobility_operation_json["operation"] = "ENTER_PORT";
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "CARGO_A");
-  ASSERT_FALSE(node->is_actively_executing_operation());
   // DROPOFF
   mobility_operation_json["operation"] = "DROPOFF";
   mobility_operation_json["cargo_id"] = "CARGO_A";
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "");
-  ASSERT_FALSE(node->is_actively_executing_operation());
   // PICKUP
   mobility_operation_json["operation"] = "PICKUP";
   mobility_operation_json["cargo_id"] = "CARGO_B";
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "CARGO_B");
-  ASSERT_FALSE(node->is_actively_executing_operation());
   // PORT CHECKPOINT
   mobility_operation_json["operation"] = "PORT_CHECKPOINT";
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "CARGO_B");
-  ASSERT_FALSE(node->is_actively_executing_operation());
   // HOLDING AREA
   mobility_operation_json["operation"] = "HOLDING_AREA";
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "CARGO_B");
-  ASSERT_FALSE(node->is_actively_executing_operation());
   // EXIT PORT
   mobility_operation_json["operation"] = "EXIT_PORT";
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "CARGO_B");
-  ASSERT_FALSE(node->is_actively_executing_operation());
   // ENTER STAGING AREA
   mobility_operation_json["operation"] = "ENTER_STAGING_AREA";
   cmd.strategy_params = mobility_operation_json.dump();
   node->on_mobility_operation_received(cmd);
-  ASSERT_TRUE(node->is_actively_executing_operation());
   node->on_result_received(result);
   ASSERT_EQ(node->get_cargo_id(), "CARGO_B");
-  ASSERT_FALSE(node->is_actively_executing_operation());
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR enables dynamic rerouting when sending MOMs commanding the CDA 1Tenth vehicle to a new destination.

Related PR: https://github.com/usdot-fhwa-stol/cda1tenth-bringup/pull/45

## Related GitHub Issue

NA

## Related Jira Key

[CF-965](https://usdot-carma.atlassian.net/browse/CF-965)

## Motivation and Context

This allows the CDA 1Tenth vehicle to have its goal preempted with a new goal and dynamically reroute to a new destination without stopping.

## How Has This Been Tested?

Tested in the turtlebot simulator

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CF-965]: https://usdot-carma.atlassian.net/browse/CF-965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ